### PR TITLE
Fix for flexible CAN baud rate (#296)

### DIFF
--- a/libraries/Arduino_CAN/src/CanUtil.cpp
+++ b/libraries/Arduino_CAN/src/CanUtil.cpp
@@ -28,7 +28,7 @@ namespace util
  **************************************************************************************/
 
 std::tuple<bool, uint32_t, uint32_t, uint32_t>
-  calc_can_bit_timing(CanBitRate const can_bitrate,
+  calc_can_bit_timing(uint32_t const can_bitrate,
                       uint32_t const can_clock_Hz,
                       uint32_t const tq_min,
                       uint32_t const tq_max,

--- a/libraries/Arduino_CAN/src/CanUtil.h
+++ b/libraries/Arduino_CAN/src/CanUtil.h
@@ -36,7 +36,7 @@ std::tuple<bool,     /* valid result found */
            uint32_t, /* baud_rate_prescaler */
            uint32_t, /* time_segment_1 */
            uint32_t> /* time_segment_2 */
-calc_can_bit_timing(CanBitRate const can_bitrate, uint32_t const can_clock_Hz, uint32_t const tq_min, uint32_t const tq_max,
+calc_can_bit_timing(uint32_t const can_bitrate, uint32_t const can_clock_Hz, uint32_t const tq_min, uint32_t const tq_max,
                     uint32_t const tseg1_min, uint32_t const tseg1_max, uint32_t const tseg2_min, uint32_t const tseg2_max);
 
 /**************************************************************************************

--- a/libraries/Arduino_CAN/src/R7FA4M1_CAN.cpp
+++ b/libraries/Arduino_CAN/src/R7FA4M1_CAN.cpp
@@ -138,6 +138,11 @@ R7FA4M1_CAN::R7FA4M1_CAN(int const can_tx_pin, int const can_rx_pin)
 
 bool R7FA4M1_CAN::begin(CanBitRate const can_bitrate)
 {
+  return begin(static_cast<uint32_t>(can_bitrate)); 
+}
+
+bool R7FA4M1_CAN::begin(uint32_t const can_bitrate)
+{
   bool init_ok = true;
 
   /* Configure the pins for CAN.

--- a/libraries/Arduino_CAN/src/R7FA4M1_CAN.h
+++ b/libraries/Arduino_CAN/src/R7FA4M1_CAN.h
@@ -52,6 +52,7 @@ public:
 
 
   bool begin(CanBitRate const can_bitrate) override;
+  bool begin(uint32_t const can_bitrate);
   void end() override;
 
   void setFilterMask_Standard(uint32_t const mask);


### PR DESCRIPTION
Fix for https://github.com/arduino/ArduinoCore-renesas/issues/295 to allow flexible bit rate either one of the 4 predefined rates or a custom rate.